### PR TITLE
Fixes installation crash.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,7 +143,7 @@ Usage
     import mf2py
     import mf2util
 
-    parsed = mf2py.Parser(url=…)
+    parsed = mf2py.Parser(url=...)
     publishedstr = parsed.to_dict()['items'][0]['properties']['published'][0]
     published = mf2util.parse_dt(published)  # --> datetime.datetime
 


### PR DESCRIPTION
Non-ascii character caused installation to fail.

Perviously:
parsed = mf2py.Parser(url=?~@?)

Error that a user would see.
Traceback (most recent call last):
  File "setup.py", line 36, in <module>
    long_description=readme(),
  File "setup.py", line 11, in readme
    return f.read()
  File "/home/redwind/venv/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 4091: ordinal not in range(128)