### PR TITLE
implement full indieweb/mf2 location algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+.cache
+mf2util.egg-info
+TAGS

--- a/tests/interpret/location_h-adr.json
+++ b/tests/interpret/location_h-adr.json
@@ -1,0 +1,25 @@
+{
+  "items": [
+    {
+      "type": [
+        "h-entry"
+      ],
+      "properties": {
+        "adr": [
+          {
+            "type": [
+              "h-adr"
+            ],
+            "properties": {
+              "street-address": ["17 Austerstræti"],
+              "locality": ["Reykjavík"],
+              "country-name": ["Iceland"],
+              "postal-code": ["107"],
+              "name": ["17 Austerstræti Reykjavík Iceland 107"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/interpret/location_h-card.json
+++ b/tests/interpret/location_h-card.json
@@ -1,0 +1,23 @@
+{
+  "items": [
+    {
+      "type": [
+        "h-entry"
+      ],
+      "properties": {
+        "location": [
+          {
+            "type": [
+              "h-card"
+            ],
+            "properties": {
+              "name": ["Timeless Coffee Roasters"],
+              "latitude": ["37.83"],
+              "longitude": ["-122.25"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/interpret/location_h-geo.json
+++ b/tests/interpret/location_h-geo.json
@@ -1,0 +1,23 @@
+{
+  "items": [
+    {
+      "type": [
+        "h-entry"
+      ],
+      "properties": {
+        "geo": [
+          {
+            "type": [
+              "h-geo"
+            ],
+            "properties": {
+              "altitude": ["123.0"],
+              "latitude": ["37.83"],
+              "longitude": ["-122.25"]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/interpret/location_top_level.json
+++ b/tests/interpret/location_top_level.json
@@ -1,0 +1,13 @@
+{
+  "items": [
+    {
+      "type": [
+        "h-entry"
+      ],
+      "properties": {
+        "latitude": ["37.83"],
+        "longitude": ["-122.25"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
...to collect properties from location, adr, geo, and top-level objects.

https://indieweb.org/location#How_to_determine_the_location_of_a_microformat

for snarfed/bridgy#706. used in snarfed/granary@55f19cdda1f98273d1ddd021d1825e23c2a96144.

assuming you're ok with this, i don't feel strongly about whether we cut a new release for it or not. i'm fine with pointing granary/bridgy's reqt's to the github repo. either way.

thanks in advance!